### PR TITLE
DCS-040 Use timezone aware dates

### DIFF
--- a/commendations/views.py
+++ b/commendations/views.py
@@ -1,6 +1,8 @@
+from datetime import datetime
 from django.http import HttpResponse
 from django.shortcuts import redirect, render
 from django.contrib import messages
+from django.utils.timezone import make_aware
 from .models import Commendation, Milestone
 from teachers.models import Teacher
 from students.models import Student
@@ -140,7 +142,9 @@ def viewMilestones(request):
 
     dateQuery = request.GET.get("date")
     if dateQuery:
-        milestones = milestones.filter(date_time__gte=dateQuery)
+        # Convert the date to a datetime object
+        date = make_aware(datetime.strptime(dateQuery, "%Y-%m-%d"))
+        milestones = milestones.filter(date_time__gte=date)
 
     # Sort by the type then by student name
     milestones = milestones.order_by(


### PR DESCRIPTION
Prevents
```
C:\Users\Matthew Gray\Documents\Code\digital-commendations\venv\lib\site-packages\django\db\models\fields\__init__.py:1534: 
RuntimeWarning: DateTimeField Milestone.date_time received a naive datetime (2022-08-30 00:00:00) while time zone support is active.
```
that is triggered when filtering milestones by date, as the HTML form returns a non-time zone aware date