### PR TITLE
DCS-058 Trailing Slashes

### DIFF
--- a/home/templates/base.html
+++ b/home/templates/base.html
@@ -36,7 +36,7 @@
         <header>
             <nav>
                 <a href="/about/">About</a>
-                <a href="/contact">Contact</a>
+                <a href="/contact/">Contact</a>
 
                 {% if request.user.is_authenticated %}
 
@@ -54,13 +54,13 @@
                         </div>
                     {% endif %}
 
-                    <a href="/logout" class="right">Logout</a>
+                    <a href="/logout/" class="right">Logout</a>
                     {% if request.user.is_staff %}
                         <a href="/admin/" class="right">Admin Site</a>
                     {% endif %}
                     
                     {% else %}
-                    <a href="/login" class="right">Login</a>
+                    <a href="/login/" class="right">Login</a>
                 {% endif %}
                 <a href="javascript:void(0);" class="icon" onclick="toggleNavResponsive()">&#9776;</a>
             </nav>
@@ -72,9 +72,9 @@
         <footer>
             <div id="footerLeft">
                 <ul>
-                    <li><a href="/about">About this project</a></li>
-                    <li><a href="/contact">Contact us</a></li>
-                    <li><a href="/privacy">Privacy and security</a></li>
+                    <li><a href="/about/">About this project</a></li>
+                    <li><a href="/contact/">Contact us</a></li>
+                    <li><a href="/privacy/">Privacy and security</a></li>
                 </ul>
             </div>
             <div id="footerCent">

--- a/home/templates/home/about.html
+++ b/home/templates/home/about.html
@@ -57,7 +57,7 @@
 
 <h2>What data does this site store? Is it safe?</h2>
 <p class="justify">
-    For information on what data this site stores, please see the <a href="{% url 'privacy' %}">Privacy Policy and security information</a>.
+    For information on what data this site stores, please see the <a href="/privacy/">Privacy Policy and security information</a>.
 </p>
 
 <hr>

--- a/home/tests.py
+++ b/home/tests.py
@@ -125,3 +125,8 @@ class TestErrorPages(TestCase):
             page500 = view_500(request)
             # Test that the 500 page is returned
             self.assertTemplateUsed(page500, "500.html")
+
+    def test_missing_slash(self):
+        # Test that a missing slash is redirected to the same URL with a trailing slash
+        response = self.client.get("/contact")
+        self.assertRedirects(response, "/contact/", status_code=301)

--- a/home/views_errors.py
+++ b/home/views_errors.py
@@ -1,5 +1,5 @@
 # Custom error views
-from django.shortcuts import render
+from django.shortcuts import redirect, render
 
 
 def error_403(request, exception):
@@ -11,6 +11,10 @@ def error_403(request, exception):
 
 def error_404(request, exception):
     """Custom 404 error view."""
+    # If there is no trailing slash, redirect to the same URL with a trailing slash
+    if not request.path.endswith("/"):
+        print("Missing trailing slash; redirecting to " + request.path + "/")
+        return redirect(request.path + "/", permanent=True)
     return render(
         request, "errors/404.html", context={"request": request, "exception": exception}
     )

--- a/students/templates/students/list_students.html
+++ b/students/templates/students/list_students.html
@@ -31,7 +31,7 @@
 <div class="allStudents">
     {% for student in students %}
         <article class="student">
-            <a href="/students/{{ student.id }}"><h2 style="font-family: 'Comfortaa', sans-serif;">{{ student.user.first_name }} {{ student.user.last_name }}</h2></a>
+            <a href="/students/{{ student.id }}/"><h2 style="font-family: 'Comfortaa', sans-serif;">{{ student.user.first_name }} {{ student.user.last_name }}</h2></a>
             ID: {{ student.id }}<br>
             Email: <a href="mailto:{{ student.user.email }}">{{ student.user.email }}</a>
             {% if student.commendations_set.count == "1" %}


### PR DESCRIPTION
No trailing slashes in URLs would cause a 404 and `APPEND_SLASH` would not trigger. 
This was because of the `handler404` that would trigger immediately and display the 404 page.

fixes #153 by adding check in `handler404` that if the path is missing a trailing slash, then if it is append one and redirect